### PR TITLE
feat: unified language pill with sliding highlight, animations, and swap-on-collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Web interface for [TranslateGemma](https://blog.google/innovation-and-ai/technology/developers-tools/translategemma/), Google's open translation model.
 
-![TranslateGemma UI](https://github.com/user-attachments/assets/8c58730a-5fe2-4e0c-a327-08db3ba49346)
+![TranslateGemma UI](https://github.com/user-attachments/assets/2b8fa87a-a251-4725-a48e-d0a500174871)
 
 ## Features
 

--- a/src/components/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector.test.tsx
@@ -2,11 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LanguageSelector } from "./LanguageSelector";
+import { DEFAULT_SOURCE_RECENTS } from "./TranslationPanel";
 
 const defaultProps = {
   onChange: vi.fn(),
-  storageKey: "srcRecents",
-  defaultRecents: ["en", "fr_FR", "de_DE", "es_MX"],
+  recents: [...DEFAULT_SOURCE_RECENTS],
+  onRecentsChange: vi.fn(),
 };
 
 describe("LanguageSelector", () => {
@@ -104,5 +105,33 @@ describe("LanguageSelector", () => {
     await user.keyboard("{Enter}");
 
     expect(onChange).toHaveBeenCalledWith("de_DE");
+  });
+
+  it("calls onRecentsChange when a language is selected", async () => {
+    const onRecentsChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LanguageSelector value="en" {...defaultProps} onRecentsChange={onRecentsChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Search languages" }));
+    await user.type(screen.getByPlaceholderText("Search languages..."), "German");
+    await user.click(within(screen.getByRole("listbox")).getByText("German"));
+
+    expect(onRecentsChange).toHaveBeenCalledWith(expect.arrayContaining(["de_DE"]));
+  });
+
+  it("shows 'Select language' when value is empty", () => {
+    render(<LanguageSelector value="" {...defaultProps} />);
+    expect(screen.getByText("Select language")).toBeInTheDocument();
+  });
+
+  it("closes dropdown on Escape key", async () => {
+    const user = userEvent.setup();
+    render(<LanguageSelector value="en" {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: "Search languages" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 });

--- a/src/components/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector.test.tsx
@@ -74,16 +74,6 @@ describe("LanguageSelector", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
-  it("excludes the language specified by excludeCode", async () => {
-    const user = userEvent.setup();
-    render(<LanguageSelector value="en" {...defaultProps} excludeCode="de_DE" />);
-
-    await user.click(screen.getByRole("button", { name: "Search languages" }));
-    await user.type(screen.getByPlaceholderText("Search languages..."), "German");
-
-    expect(screen.getByText("No languages found")).toBeInTheDocument();
-  });
-
   it("marks selected language option with aria-selected", async () => {
     const user = userEvent.setup();
     render(<LanguageSelector value="en" {...defaultProps} />);
@@ -107,7 +97,19 @@ describe("LanguageSelector", () => {
     expect(onChange).toHaveBeenCalledWith("de_DE");
   });
 
-  it("calls onRecentsChange when a language is selected", async () => {
+  it("calls onRecentsChange when a new language is selected", async () => {
+    const onRecentsChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LanguageSelector value="en" {...defaultProps} onRecentsChange={onRecentsChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Search languages" }));
+    await user.type(screen.getByPlaceholderText("Search languages..."), "Japan");
+    await user.click(within(screen.getByRole("listbox")).getByText("Japanese"));
+
+    expect(onRecentsChange).toHaveBeenCalledWith(expect.arrayContaining(["ja_JP"]));
+  });
+
+  it("does not call onRecentsChange when selecting an existing recent", async () => {
     const onRecentsChange = vi.fn();
     const user = userEvent.setup();
     render(<LanguageSelector value="en" {...defaultProps} onRecentsChange={onRecentsChange} />);
@@ -116,7 +118,8 @@ describe("LanguageSelector", () => {
     await user.type(screen.getByPlaceholderText("Search languages..."), "German");
     await user.click(within(screen.getByRole("listbox")).getByText("German"));
 
-    expect(onRecentsChange).toHaveBeenCalledWith(expect.arrayContaining(["de_DE"]));
+    // de_DE is already in DEFAULT_SOURCE_RECENTS, so recents should not change
+    expect(onRecentsChange).not.toHaveBeenCalled();
   });
 
   it("shows 'Select language' when value is empty", () => {

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -59,9 +59,7 @@ export function LanguageSelector({
   defaultRecents,
   dropdownAnchorRef,
 }: LanguageSelectorProps) {
-  const [recents, setRecents] = useState<string[]>(() =>
-    loadRecents(storageKey, defaultRecents)
-  );
+  const [recents, setRecents] = useState<string[]>(() => loadRecents(storageKey, defaultRecents));
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -76,7 +74,9 @@ export function LanguageSelector({
       return;
     }
     const el = dropdownAnchorRef.current;
-    const measure = () => setAnchorRect(el.getBoundingClientRect());
+    const measure = () => {
+      setAnchorRect(el.getBoundingClientRect());
+    };
     measure();
     window.addEventListener("scroll", measure, true);
     window.addEventListener("resize", measure);
@@ -205,7 +205,7 @@ export function LanguageSelector({
           onClick={() => {
             setIsOpen(true);
           }}
-          className={`flex-1 truncate rounded-full px-3 py-1.5 text-left text-sm font-medium md:hidden transition-colors ${
+          className={`flex-1 truncate rounded-full px-3 py-1.5 text-left text-sm font-medium transition-colors md:hidden ${
             isOpen
               ? "bg-zinc-300 text-zinc-800 ring-1 ring-zinc-500 dark:bg-zinc-600 dark:text-zinc-100 dark:ring-zinc-400"
               : "bg-zinc-200 text-zinc-800 dark:bg-zinc-700 dark:text-zinc-100"
@@ -217,9 +217,7 @@ export function LanguageSelector({
         </button>
 
         {/* Wide: recent language pills — flex-1 pushes search icon to the right; mask fades edges when clipped */}
-        <div
-          className="hidden min-w-0 flex-1 items-center gap-1 overflow-hidden md:flex [mask-image:linear-gradient(to_right,black_0,black_calc(100%-1.5rem),transparent_100%)] [-webkit-mask-image:linear-gradient(to_right,black_0,black_calc(100%-1.5rem),transparent_100%)]"
-        >
+        <div className="hidden min-w-0 flex-1 items-center gap-1 overflow-hidden [mask-image:linear-gradient(to_right,black_0,black_calc(100%-1.5rem),transparent_100%)] [-webkit-mask-image:linear-gradient(to_right,black_0,black_calc(100%-1.5rem),transparent_100%)] md:flex">
           {visibleTabs.map((code) => {
             const isActive = code === value;
             return (
@@ -275,7 +273,7 @@ export function LanguageSelector({
             className={
               anchorRect
                 ? "z-20 flex flex-col rounded-lg border border-zinc-100 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-800"
-                : "absolute top-full left-0 z-20 mt-2 w-full min-w-64 flex flex-col rounded-lg border border-zinc-100 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-800"
+                : "absolute top-full left-0 z-20 mt-2 flex w-full min-w-64 flex-col rounded-lg border border-zinc-100 bg-white shadow-lg dark:border-zinc-800 dark:bg-zinc-800"
             }
             style={dropdownStyle ?? undefined}
           >

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -7,16 +7,33 @@ const MAX_RECENTS = 4;
 /** Below this height the anchor is a language row (mobile), not a textarea panel (desktop). */
 const MOBILE_ANCHOR_THRESHOLD = 100;
 
+/** Minimum usable dropdown height before we flip above the anchor. */
+const MIN_DROPDOWN_HEIGHT = 160;
+
 function getDropdownPosition(rect: DOMRect) {
   if (rect.height < MOBILE_ANCHOR_THRESHOLD) {
-    const remaining = window.innerHeight - rect.bottom - 16;
+    const spaceBelow = window.innerHeight - rect.bottom - 16;
+    const spaceAbove = rect.top - 16;
     const maxHeight = Math.min(560, window.innerHeight * 0.7);
+
+    // Flip above the anchor when space below is too tight and there's more room above
+    if (spaceBelow < MIN_DROPDOWN_HEIGHT && spaceAbove > spaceBelow) {
+      const height = Math.min(spaceAbove, maxHeight);
+      return {
+        position: "fixed" as const,
+        top: rect.top - height - 8,
+        left: rect.left,
+        width: rect.width,
+        height,
+      };
+    }
+
     return {
       position: "fixed" as const,
       top: rect.bottom + 8,
       left: rect.left,
       width: rect.width,
-      height: Math.min(remaining, maxHeight),
+      height: Math.min(spaceBelow, maxHeight),
     };
   }
   return {

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -55,8 +55,9 @@ export function LanguageSelector({
   storageKey,
   defaultRecents,
 }: LanguageSelectorProps) {
-  // Initialized with safe SSR defaults; localStorage values applied on mount via useEffect
-  const [recents, setRecents] = useState<string[]>(defaultRecents);
+  const [recents, setRecents] = useState<string[]>(() =>
+    loadRecents(storageKey, defaultRecents)
+  );
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -96,13 +97,6 @@ export function LanguageSelector({
     },
     [recents, onChange, storageKey, close]
   );
-
-  // Restore recents from localStorage on mount (client-only).
-  // storageKey and defaultRecents are module-level constants — stable references.
-  useEffect(() => {
-    const stored = loadRecents(storageKey, defaultRecents);
-    setRecents(stored);
-  }, [storageKey, defaultRecents]);
 
   // Keep value in recents when it changes externally (e.g. swap)
   useEffect(() => {

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -162,13 +162,16 @@ export function LanguageSelector({
 
   // Track which tabs are newly added (for enter animation)
   const prevVisibleTabsRef = useRef<string[] | null>(null);
-  const newTabCodes = useMemo(() => {
-    if (prevVisibleTabsRef.current === null) return new Set<string>();
-    const prevSet = new Set(prevVisibleTabsRef.current);
-    return new Set(visibleTabs.filter((code) => !prevSet.has(code)));
-  }, [visibleTabs]);
+  const [newTabCodes, setNewTabCodes] = useState<Set<string>>(new Set());
 
   useEffect(() => {
+    if (prevVisibleTabsRef.current !== null) {
+      const prevSet = new Set(prevVisibleTabsRef.current);
+      const added = visibleTabs.filter((code) => !prevSet.has(code));
+      if (added.length > 0) {
+        setNewTabCodes(new Set(added));
+      }
+    }
     prevVisibleTabsRef.current = visibleTabs;
   }, [visibleTabs]);
 
@@ -300,7 +303,14 @@ export function LanguageSelector({
                 onClick={() => {
                   select(code);
                 }}
-                onAnimationEnd={isNew ? measureHighlight : undefined}
+                onAnimationEnd={
+                  isNew
+                    ? () => {
+                        setNewTabCodes(new Set());
+                        measureHighlight();
+                      }
+                    : undefined
+                }
                 className={[
                   "relative z-10 rounded-2xl px-3.5 py-2 text-[13px] font-medium whitespace-nowrap transition-colors",
                   isNew ? "pill-enter" : "",

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -154,7 +154,7 @@ export function LanguageSelector({
     [isOpen, focusedIndex, filteredLanguages, select, close]
   );
 
-  const selectedName = getLanguageName(value);
+  const selectedName = value ? getLanguageName(value) : "Select language";
 
   return (
     <div className="relative w-full min-w-0">

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -295,7 +295,7 @@ export function LanguageSelector({
                 ? "z-20 flex flex-col rounded-2xl bg-white shadow-xl ring-1 ring-zinc-900/5 dark:bg-zinc-800 dark:ring-zinc-100/10"
                 : "absolute top-full left-0 z-20 mt-2 flex w-full min-w-64 flex-col rounded-2xl bg-white shadow-xl ring-1 ring-zinc-900/5 dark:bg-zinc-800 dark:ring-zinc-100/10"
             }
-            style={dropdownStyle ?? undefined}
+            style={dropdownStyle}
           >
             <div className="shrink-0 p-2.5">
               <input

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -18,7 +18,7 @@ function getDropdownPosition(rect: DOMRect) {
 
     // Flip above the anchor when space below is too tight and there's more room above
     if (spaceBelow < MIN_DROPDOWN_HEIGHT && spaceAbove > spaceBelow) {
-      const height = Math.min(spaceAbove, maxHeight);
+      const height = Math.max(Math.min(spaceAbove, maxHeight), 0);
       return {
         position: "fixed" as const,
         top: rect.top - height - 8,
@@ -33,7 +33,7 @@ function getDropdownPosition(rect: DOMRect) {
       top: rect.bottom + 8,
       left: rect.left,
       width: rect.width,
-      height: Math.min(spaceBelow, maxHeight),
+      height: Math.max(Math.min(spaceBelow, maxHeight), 0),
     };
   }
   return {

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -273,9 +273,10 @@ export function LanguageSelector({
           className="relative hidden min-w-0 flex-1 items-center overflow-hidden [mask-image:linear-gradient(to_right,black_0,black_calc(100%-1.5rem),transparent_100%)] [-webkit-mask-image:linear-gradient(to_right,black_0,black_calc(100%-1.5rem),transparent_100%)] md:flex"
         >
           {/* Sliding highlight behind active tab */}
-          {highlightStyle && (
+          {/* Sliding highlight — hidden while active tab is animating in */}
+          {highlightStyle && !newTabCodes.has(value) && (
             <div
-              className="absolute top-0 bottom-0 rounded-2xl bg-white/50 transition-[left,width] duration-300 ease-in-out dark:bg-zinc-600/50"
+              className="absolute top-0 bottom-0 rounded-2xl bg-white/50 transition-[left,width] duration-300 ease-out dark:bg-zinc-600/50"
               style={{
                 left: highlightStyle.left,
                 width: highlightStyle.width,
@@ -300,13 +301,16 @@ export function LanguageSelector({
                   select(code);
                 }}
                 onAnimationEnd={isNew ? measureHighlight : undefined}
-                className={`relative z-10 rounded-2xl px-3.5 py-2 text-[13px] font-medium whitespace-nowrap transition-colors ${
-                  isNew ? "pill-enter" : ""
-                } ${
+                className={[
+                  "relative z-10 rounded-2xl px-3.5 py-2 text-[13px] font-medium whitespace-nowrap transition-colors",
+                  isNew ? "pill-enter" : "",
                   isActive
                     ? "text-zinc-800 dark:text-zinc-100"
-                    : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
-                }`}
+                    : "text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200",
+                  isActive && isNew ? "bg-white/50 dark:bg-zinc-600/50" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
               >
                 {getLanguageName(code)}
               </button>

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -118,10 +118,10 @@ export function LanguageSelector({
       setAnchorRect(el.getBoundingClientRect());
     };
     measure();
-    window.addEventListener("scroll", measure, true);
-    window.addEventListener("resize", measure);
+    window.addEventListener("scroll", measure, { capture: true, passive: true });
+    window.addEventListener("resize", measure, { passive: true });
     return () => {
-      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("scroll", measure, { capture: true });
       window.removeEventListener("resize", measure);
     };
   }, [useAnchor, dropdownAnchorRef]);

--- a/src/components/TranslationPanel.test.tsx
+++ b/src/components/TranslationPanel.test.tsx
@@ -23,18 +23,30 @@ async function selectTargetLanguage(
   return langCode;
 }
 
+function mockMatchMedia(matches = false) {
+  const listeners: ((e: { matches: boolean }) => void)[] = [];
+  Object.defineProperty(window, "matchMedia", {
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      addEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+        listeners.push(cb);
+      },
+      removeEventListener: (_: string, cb: (e: { matches: boolean }) => void) => {
+        const idx = listeners.indexOf(cb);
+        if (idx >= 0) listeners.splice(idx, 1);
+      },
+    })),
+    writable: true,
+  });
+  return listeners;
+}
+
 describe("TranslationPanel", () => {
   beforeEach(() => {
     mockTranslate.mockReset();
-    Object.defineProperty(window, "matchMedia", {
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
-        media: query,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      })),
-      writable: true,
-    });
+    localStorage.clear();
+    mockMatchMedia(false);
   });
 
   it("renders source and target language search buttons", () => {
@@ -196,5 +208,60 @@ describe("TranslationPanel", () => {
     await user.type(screen.getByPlaceholderText("Enter text to translate..."), "Hello");
 
     expect(screen.getByText("5 chars")).toBeInTheDocument();
+  });
+
+  it("restores languages from localStorage", () => {
+    localStorage.setItem("srcLang", "de_DE");
+    localStorage.setItem("tgtLang", "ja_JP");
+
+    render(<TranslationPanel />);
+
+    // The language pills should show the stored languages
+    expect(screen.getAllByText("German").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Japanese").length).toBeGreaterThan(0);
+  });
+
+  it("ignores invalid language codes in localStorage", () => {
+    localStorage.setItem("srcLang", "not_a_language");
+    localStorage.setItem("tgtLang", "also_invalid");
+
+    render(<TranslationPanel />);
+
+    // Should fall back to defaults (English source, French target)
+    expect(screen.getAllByText("English").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("French (France)").length).toBeGreaterThan(0);
+  });
+
+  it("falls back to defaults when localStorage throws", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+
+    render(<TranslationPanel />);
+
+    // Should render with default languages
+    expect(screen.getAllByText("English").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("French (France)").length).toBeGreaterThan(0);
+
+    getItemSpy.mockRestore();
+  });
+
+  it("swaps source and target languages", async () => {
+    localStorage.setItem("srcLang", "en");
+    localStorage.setItem("tgtLang", "de_DE");
+
+    const user = userEvent.setup();
+    render(<TranslationPanel />);
+
+    // Verify initial state
+    const searchButtons = screen.getAllByRole("button", { name: "Search languages" });
+    expect(searchButtons).toHaveLength(2);
+
+    await user.click(screen.getByTitle("Swap languages"));
+
+    // After swap: source should be German, target should be English
+    // The swap button persists to localStorage — verify via the stored values
+    expect(localStorage.getItem("srcLang")).toBe("de_DE");
+    expect(localStorage.getItem("tgtLang")).toBe("en");
   });
 });

--- a/src/components/TranslationPanel.test.tsx
+++ b/src/components/TranslationPanel.test.tsx
@@ -26,6 +26,15 @@ async function selectTargetLanguage(
 describe("TranslationPanel", () => {
   beforeEach(() => {
     mockTranslate.mockReset();
+    Object.defineProperty(window, "matchMedia", {
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+      writable: true,
+    });
   });
 
   it("renders source and target language search buttons", () => {

--- a/src/components/TranslationPanel.test.tsx
+++ b/src/components/TranslationPanel.test.tsx
@@ -199,6 +199,25 @@ describe("TranslationPanel", () => {
     expect(screen.getByText("Translation will appear here")).toBeInTheDocument();
   });
 
+  it("swaps languages when selecting a language matching the other side", async () => {
+    localStorage.setItem("srcLang", "en");
+    localStorage.setItem("tgtLang", "fr_FR");
+
+    const user = userEvent.setup();
+    render(<TranslationPanel />);
+
+    // Select French as source (same as target) — should swap target to English
+    const searchButtons = screen.getAllByRole("button", { name: "Search languages" });
+    const sourceButton = searchButtons[0];
+    if (!sourceButton) throw new Error("Expected source language search button");
+    await user.click(sourceButton);
+    await user.type(screen.getByPlaceholderText("Search languages..."), "French (France)");
+    await user.click(within(screen.getByRole("listbox")).getByText("French (France)"));
+
+    expect(localStorage.getItem("srcLang")).toBe("fr_FR");
+    expect(localStorage.getItem("tgtLang")).toBe("en");
+  });
+
   it("shows character count", async () => {
     const user = userEvent.setup();
     render(<TranslationPanel />);

--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -293,6 +293,9 @@ export function TranslationPanel() {
                 value={sourceLanguage}
                 onChange={(code) => {
                   if (code === targetLanguage) {
+                    cancelPendingRequest();
+                    setError(null);
+                    setStats(null);
                     setTargetLanguage(sourceLanguage);
                     setLocalStorage("tgtLang", sourceLanguage);
                     setSourceText(translatedText);
@@ -331,6 +334,9 @@ export function TranslationPanel() {
                 value={targetLanguage}
                 onChange={(code) => {
                   if (code === sourceLanguage) {
+                    cancelPendingRequest();
+                    setError(null);
+                    setStats(null);
                     setSourceLanguage(targetLanguage);
                     setLocalStorage("srcLang", targetLanguage);
                     setSourceText(translatedText);

--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -3,8 +3,8 @@ import { LanguageSelector } from "./LanguageSelector";
 import { translate } from "~/serverFunctions/translate";
 import { VALID_LANGUAGE_CODES } from "~/lib/languages";
 
-const DEFAULT_SOURCE_RECENTS = ["en", "fr_FR", "de_DE", "es_MX"];
-const DEFAULT_TARGET_RECENTS = ["fr_FR", "de_DE", "es_MX", "ja_JP"];
+const DEFAULT_SOURCE_RECENTS = ["en", "fr_FR", "de_DE", "es_MX"] as const;
+const DEFAULT_TARGET_RECENTS = ["fr_FR", "de_DE", "es_MX", "ja_JP"] as const;
 
 function setLocalStorage(key: string, value: string) {
   try {
@@ -35,15 +35,17 @@ export function TranslationPanel() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Restore language preferences from localStorage on mount (client-only)
+  // Restore language preferences from localStorage on mount (client-only).
+  // In incognito/strict private browsing localStorage may be empty or throw, so default target to first recent.
   useEffect(() => {
     try {
       const src = localStorage.getItem("srcLang");
       const tgt = localStorage.getItem("tgtLang");
       if (src && VALID_LANGUAGE_CODES.has(src)) setSourceLanguage(src);
       if (tgt && VALID_LANGUAGE_CODES.has(tgt)) setTargetLanguage(tgt);
+      else setTargetLanguage(DEFAULT_TARGET_RECENTS[0]);
     } catch {
-      // localStorage unavailable (e.g. private browsing with strict settings)
+      setTargetLanguage(DEFAULT_TARGET_RECENTS[0]);
     }
   }, []);
 
@@ -202,7 +204,7 @@ export function TranslationPanel() {
             }}
             excludeCode={targetLanguage}
             storageKey="srcRecents"
-            defaultRecents={DEFAULT_SOURCE_RECENTS}
+            defaultRecents={[...DEFAULT_SOURCE_RECENTS]}
           />
         </div>
 
@@ -231,7 +233,7 @@ export function TranslationPanel() {
             }}
             excludeCode={sourceLanguage}
             storageKey="tgtRecents"
-            defaultRecents={DEFAULT_TARGET_RECENTS}
+            defaultRecents={[...DEFAULT_TARGET_RECENTS]}
           />
         </div>
       </div>

--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -45,10 +45,14 @@ export function TranslationPanel() {
   const [isWideView, setIsWideView] = useState(false);
   useEffect(() => {
     const mql = window.matchMedia("(min-width: 768px)");
-    const update = () => setIsWideView(mql.matches);
+    const update = () => {
+      setIsWideView(mql.matches);
+    };
     update();
     mql.addEventListener("change", update);
-    return () => mql.removeEventListener("change", update);
+    return () => {
+      mql.removeEventListener("change", update);
+    };
   }, []);
 
   // Track request ID to ignore stale responses

--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -38,6 +38,18 @@ export function TranslationPanel() {
 
   const [copied, setCopied] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const sourcePanelRef = useRef<HTMLDivElement>(null);
+  const targetPanelRef = useRef<HTMLDivElement>(null);
+  const languageRowRef = useRef<HTMLDivElement>(null);
+
+  const [isWideView, setIsWideView] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia("(min-width: 768px)");
+    const update = () => setIsWideView(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
 
   // Track request ID to ignore stale responses
   const requestIdRef = useRef(0);
@@ -189,7 +201,7 @@ export function TranslationPanel() {
   return (
     <div className="mx-auto w-full max-w-5xl">
       {/* Language selectors */}
-      <div className="mb-4 flex items-center gap-2">
+      <div ref={languageRowRef} className="mb-4 flex items-center gap-2">
         <div className="min-w-0 flex-1">
           <LanguageSelector
             value={sourceLanguage}
@@ -200,6 +212,7 @@ export function TranslationPanel() {
             excludeCode={targetLanguage}
             storageKey="srcRecents"
             defaultRecents={sourceDefaultRecents}
+            dropdownAnchorRef={isWideView ? sourcePanelRef : languageRowRef}
           />
         </div>
 
@@ -229,6 +242,7 @@ export function TranslationPanel() {
             excludeCode={sourceLanguage}
             storageKey="tgtRecents"
             defaultRecents={targetDefaultRecents}
+            dropdownAnchorRef={isWideView ? targetPanelRef : languageRowRef}
           />
         </div>
       </div>
@@ -236,7 +250,10 @@ export function TranslationPanel() {
       {/* Text areas */}
       <div className="grid gap-4 md:grid-cols-2">
         {/* Source text */}
-        <div className="flex flex-col rounded-lg border border-zinc-100 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800">
+        <div
+          ref={sourcePanelRef}
+          className="flex flex-col rounded-lg border border-zinc-100 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800"
+        >
           <textarea
             ref={textareaRef}
             value={sourceText}
@@ -267,7 +284,10 @@ export function TranslationPanel() {
         </div>
 
         {/* Translated text */}
-        <div className="flex flex-col rounded-lg border border-zinc-100 bg-zinc-50 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+        <div
+          ref={targetPanelRef}
+          className="flex flex-col rounded-lg border border-zinc-100 bg-zinc-50 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+        >
           <div
             className={`min-h-48 flex-1 p-4 text-lg whitespace-pre-wrap ${
               isLoading ? "streaming-cursor" : ""

--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -1,15 +1,11 @@
-import { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import { LanguageSelector } from "./LanguageSelector";
+import { useState, useCallback, useRef, useEffect, useLayoutEffect } from "react";
+import { LanguageSelector, loadRecents, addToRecents, saveRecents } from "./LanguageSelector";
 import { translate } from "~/serverFunctions/translate";
 import { VALID_LANGUAGE_CODES } from "~/lib/languages";
 
-const DEFAULT_SOURCE_RECENTS = ["en", "fr_FR", "de_DE", "es_MX"] as const;
-const DEFAULT_TARGET_RECENTS = ["fr_FR", "de_DE", "es_MX", "ja_JP"] as const;
-
-const srcLang = localStorage.getItem("srcLang") ?? "";
-const src = VALID_LANGUAGE_CODES.has(srcLang) ? srcLang : DEFAULT_SOURCE_RECENTS[0];
-const tgtLang = localStorage.getItem("tgtLang") ?? "";
-const tgt = VALID_LANGUAGE_CODES.has(tgtLang) ? tgtLang : DEFAULT_TARGET_RECENTS[0];
+/** Default recent language codes; exported for tests. */
+export const DEFAULT_SOURCE_RECENTS = ["en", "fr_FR", "de_DE", "es_MX"] as const;
+export const DEFAULT_TARGET_RECENTS = ["fr_FR", "de_DE", "es_MX", "ja_JP"] as const;
 
 function setLocalStorage(key: string, value: string) {
   try {
@@ -23,13 +19,92 @@ export function TranslationPanel() {
   const [sourceText, setSourceText] = useState("");
   const [translatedText, setTranslatedText] = useState("");
 
-  // Stable array refs for defaultRecents so LanguageSelector's mount-only useEffect doesn't re-run every render.
-  const sourceDefaultRecents = useMemo(() => [...DEFAULT_SOURCE_RECENTS], []);
-  const targetDefaultRecents = useMemo(() => [...DEFAULT_TARGET_RECENTS], []);
+  // SSR-safe: same initial state on server and client. Single state so restore + hasRestored update in one commit — fade-in only after content is ready.
+  const [languageState, setLanguageState] = useState<{
+    sourceLanguage: string;
+    targetLanguage: string;
+    sourceRecents: string[];
+    targetRecents: string[];
+    hasRestored: boolean;
+  }>({
+    sourceLanguage: DEFAULT_SOURCE_RECENTS[0],
+    targetLanguage: DEFAULT_TARGET_RECENTS[0],
+    sourceRecents: [...DEFAULT_SOURCE_RECENTS],
+    targetRecents: [...DEFAULT_TARGET_RECENTS],
+    hasRestored: false,
+  });
+  const { sourceLanguage, targetLanguage, sourceRecents, targetRecents, hasRestored } =
+    languageState;
 
-  const [sourceLanguage, setSourceLanguage] = useState<string>(src);
-  const [targetLanguage, setTargetLanguage] = useState<string>(tgt);
+  useLayoutEffect(() => {
+    try {
+      const storedSrc = localStorage.getItem("srcLang");
+      const storedTgt = localStorage.getItem("tgtLang");
+      const src =
+        storedSrc && VALID_LANGUAGE_CODES.has(storedSrc) ? storedSrc : DEFAULT_SOURCE_RECENTS[0];
+      const tgt =
+        storedTgt && VALID_LANGUAGE_CODES.has(storedTgt) ? storedTgt : DEFAULT_TARGET_RECENTS[0];
+      const loadedSourceRecents = loadRecents("srcRecents", [...DEFAULT_SOURCE_RECENTS]);
+      const loadedTargetRecents = loadRecents("tgtRecents", [...DEFAULT_TARGET_RECENTS]);
+      // Normalize order so selected language is first; avoids "keep value in recents" effect firing after restore (extra render)
+      const next = {
+        sourceLanguage: src,
+        targetLanguage: tgt,
+        sourceRecents: addToRecents(loadedSourceRecents, src),
+        targetRecents: addToRecents(loadedTargetRecents, tgt),
+        hasRestored: true,
+      };
+      setLanguageState(next);
+      // Set isWideView in same tick so we don't get an extra render from the matchMedia useEffect
+      const mql = window.matchMedia("(min-width: 768px)");
+      setIsWideView(mql.matches);
+    } catch {
+      setLanguageState((prev) => ({ ...prev, hasRestored: true }));
+    }
+  }, []);
+
+  const setSourceLanguage = useCallback((code: string) => {
+    setLanguageState((prev) => ({ ...prev, sourceLanguage: code }));
+  }, []);
+  const setTargetLanguage = useCallback((code: string) => {
+    setLanguageState((prev) => ({ ...prev, targetLanguage: code }));
+  }, []);
+  const setSourceRecents = useCallback((next: string[]) => {
+    setLanguageState((prev) => ({ ...prev, sourceRecents: next }));
+  }, []);
+  const setTargetRecents = useCallback((next: string[]) => {
+    setLanguageState((prev) => ({ ...prev, targetRecents: next }));
+  }, []);
   const [isLoading, setIsLoading] = useState(false);
+
+  // Keep value in recents when it changes externally (e.g. swap); skip if already first to avoid reorder flash after restore
+  useEffect(() => {
+    if (
+      !sourceLanguage ||
+      !VALID_LANGUAGE_CODES.has(sourceLanguage) ||
+      sourceRecents[0] === sourceLanguage
+    )
+      return;
+    setLanguageState((prev) => {
+      const next = addToRecents(prev.sourceRecents, sourceLanguage);
+      saveRecents("srcRecents", next);
+      return { ...prev, sourceRecents: next };
+    });
+  }, [sourceLanguage, sourceRecents]);
+  useEffect(() => {
+    if (
+      !targetLanguage ||
+      !VALID_LANGUAGE_CODES.has(targetLanguage) ||
+      targetRecents[0] === targetLanguage
+    )
+      return;
+    setLanguageState((prev) => {
+      const next = addToRecents(prev.targetRecents, targetLanguage);
+      saveRecents("tgtRecents", next);
+      return { ...prev, targetRecents: next };
+    });
+  }, [targetLanguage, targetRecents]);
+
   const [error, setError] = useState<string | null>(null);
   const [stats, setStats] = useState<{
     duration?: number;
@@ -204,59 +279,69 @@ export function TranslationPanel() {
 
   return (
     <div className="mx-auto w-full max-w-5xl">
-      {/* Language selectors */}
-      <div ref={languageRowRef} className="mb-4 flex items-center gap-2">
-        <div className="min-w-0 flex-1">
-          <LanguageSelector
-            value={sourceLanguage}
-            onChange={(code) => {
-              setSourceLanguage(code);
-              setLocalStorage("srcLang", code);
-            }}
-            excludeCode={targetLanguage}
-            storageKey="srcRecents"
-            defaultRecents={sourceDefaultRecents}
-            dropdownAnchorRef={isWideView ? sourcePanelRef : languageRowRef}
-          />
-        </div>
+      {/* Language selectors — only mount when restored so DOM never has default pill text (avoids flash) */}
+      <div ref={languageRowRef} className="mb-3 flex min-h-10 items-center gap-3">
+        {hasRestored ? (
+          <div className="fade-in flex min-w-0 flex-1 items-center gap-3">
+            <div className="min-w-0 flex-1">
+              <LanguageSelector
+                value={sourceLanguage}
+                onChange={(code) => {
+                  setSourceLanguage(code);
+                  setLocalStorage("srcLang", code);
+                }}
+                excludeCode={targetLanguage}
+                recents={sourceRecents}
+                onRecentsChange={(next) => {
+                  setSourceRecents(next);
+                  saveRecents("srcRecents", next);
+                }}
+                dropdownAnchorRef={isWideView ? sourcePanelRef : languageRowRef}
+              />
+            </div>
 
-        <button
-          type="button"
-          onClick={handleSwapLanguages}
-          className="rounded-full p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
-          title="Swap languages"
-        >
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-            />
-          </svg>
-        </button>
+            <button
+              type="button"
+              onClick={handleSwapLanguages}
+              className="rounded-full p-2 text-zinc-300 transition-colors hover:bg-zinc-100 hover:text-zinc-500 dark:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-400"
+              title="Swap languages"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
+                />
+              </svg>
+            </button>
 
-        <div className="min-w-0 flex-1">
-          <LanguageSelector
-            value={targetLanguage}
-            onChange={(code) => {
-              setTargetLanguage(code);
-              setLocalStorage("tgtLang", code);
-            }}
-            excludeCode={sourceLanguage}
-            storageKey="tgtRecents"
-            defaultRecents={targetDefaultRecents}
-            dropdownAnchorRef={isWideView ? targetPanelRef : languageRowRef}
-          />
-        </div>
+            <div className="min-w-0 flex-1">
+              <LanguageSelector
+                value={targetLanguage}
+                onChange={(code) => {
+                  setTargetLanguage(code);
+                  setLocalStorage("tgtLang", code);
+                }}
+                excludeCode={sourceLanguage}
+                recents={targetRecents}
+                onRecentsChange={(next) => {
+                  setTargetRecents(next);
+                  saveRecents("tgtRecents", next);
+                }}
+                dropdownAnchorRef={isWideView ? targetPanelRef : languageRowRef}
+              />
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {/* Text areas */}
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-3 md:grid-cols-2">
         {/* Source text */}
         <div
           ref={sourcePanelRef}
-          className="flex flex-col rounded-lg border border-zinc-100 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-800"
+          className="flex flex-col rounded-2xl bg-white shadow-sm ring-1 ring-zinc-900/5 dark:bg-zinc-800 dark:ring-zinc-100/10"
         >
           <textarea
             ref={textareaRef}
@@ -265,13 +350,13 @@ export function TranslationPanel() {
               setSourceText(e.target.value);
             }}
             placeholder="Enter text to translate..."
-            className="min-h-48 w-full resize-none overflow-hidden bg-transparent p-4 text-lg focus:outline-none"
+            className="min-h-48 w-full resize-none overflow-hidden bg-transparent p-5 text-lg focus:outline-none"
           />
-          <div className="flex h-10 items-center justify-end gap-2 border-t border-zinc-100 px-3 dark:border-zinc-800">
+          <div className="flex h-10 items-center justify-end gap-3 border-t border-zinc-100/60 px-4 dark:border-zinc-700/40">
             <button
               type="button"
               onClick={handleClear}
-              className={`rounded-md p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300 ${!sourceText ? "invisible" : ""}`}
+              className={`rounded-full p-1 text-zinc-300 transition-colors hover:bg-zinc-100 hover:text-zinc-500 dark:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-400 ${!sourceText ? "invisible" : ""}`}
               title="Clear"
             >
               <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -283,17 +368,19 @@ export function TranslationPanel() {
                 />
               </svg>
             </button>
-            <span className="text-sm text-zinc-400">{sourceText.length} chars</span>
+            <span className="text-xs text-zinc-300 dark:text-zinc-600">
+              {sourceText.length} chars
+            </span>
           </div>
         </div>
 
         {/* Translated text */}
         <div
           ref={targetPanelRef}
-          className="flex flex-col rounded-lg border border-zinc-100 bg-zinc-50 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+          className="flex flex-col rounded-2xl bg-zinc-50 shadow-sm ring-1 ring-zinc-900/5 dark:bg-zinc-900 dark:ring-zinc-100/10"
         >
           <div
-            className={`min-h-48 flex-1 p-4 text-lg whitespace-pre-wrap ${
+            className={`min-h-48 flex-1 p-5 text-lg whitespace-pre-wrap ${
               isLoading ? "streaming-cursor" : ""
             }`}
           >
@@ -304,14 +391,14 @@ export function TranslationPanel() {
             ) : isLoading ? (
               <span className="text-zinc-400">Translating...</span>
             ) : (
-              <span className="text-zinc-400">Translation will appear here</span>
+              <span className="text-zinc-300 dark:text-zinc-600">Translation will appear here</span>
             )}
           </div>
-          <div className="flex h-10 items-center justify-end gap-2 border-t border-zinc-100 px-3 dark:border-zinc-800">
+          <div className="flex h-10 items-center justify-end gap-3 border-t border-zinc-100/60 px-4 dark:border-zinc-700/40">
             <button
               type="button"
               onClick={handleCopy}
-              className={`rounded-md p-1 transition-colors ${copied ? "text-green-500" : "text-zinc-400 hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"} ${!translatedText ? "invisible" : ""}`}
+              className={`rounded-full p-1 transition-colors ${copied ? "text-green-500" : "text-zinc-300 hover:bg-zinc-100 hover:text-zinc-500 dark:text-zinc-600 dark:hover:bg-zinc-700 dark:hover:text-zinc-400"} ${!translatedText ? "invisible" : ""}`}
               title={copied ? "Copied!" : "Copy to clipboard"}
             >
               {copied ? (
@@ -335,8 +422,8 @@ export function TranslationPanel() {
               )}
             </button>
             {stats && (
-              <span className="text-xs text-zinc-400">
-                {stats.duration}s{stats.tokens !== undefined && ` • ${String(stats.tokens)} tokens`}
+              <span className="text-xs text-zinc-300 dark:text-zinc-600">
+                {stats.duration}s{stats.tokens !== undefined && ` · ${String(stats.tokens)} tokens`}
               </span>
             )}
           </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/")({
 
 function HomePage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-zinc-50 to-zinc-100 px-4 py-8 dark:from-zinc-950 dark:to-zinc-900">
+    <div className="min-h-screen px-5 py-10 dark:bg-zinc-950">
       <TranslationPanel />
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,27 @@ body {
   animation: fade-in 0.35s ease-out forwards;
 }
 
+/* Pill enter — new tab grows from 0 width */
+@keyframes pill-enter {
+  from {
+    max-width: 0;
+    padding-left: 0;
+    padding-right: 0;
+    opacity: 0;
+  }
+  to {
+    max-width: 12rem;
+    padding-left: 0.875rem;
+    padding-right: 0.875rem;
+    opacity: 1;
+  }
+}
+
+.pill-enter {
+  animation: pill-enter 0.3s ease-out forwards;
+  overflow: hidden;
+}
+
 /* Streaming animation */
 @keyframes pulse-opacity {
   0%,

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,22 +8,36 @@ body {
   @apply bg-zinc-50 text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-100;
 }
 
-/* Custom scrollbar */
+/* Custom scrollbar — thin, minimal */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-zinc-100 dark:bg-zinc-800;
+  @apply bg-transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply rounded-full bg-zinc-300 dark:bg-zinc-600;
+  @apply rounded-full bg-zinc-300/60 dark:bg-zinc-600/60;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-zinc-400 dark:bg-zinc-500;
+  @apply bg-zinc-400/80 dark:bg-zinc-500/80;
+}
+
+/* Fade-in for language row after restore */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-in {
+  animation: fade-in 0.35s ease-out forwards;
 }
 
 /* Streaming animation */


### PR DESCRIPTION
![TranslateGemma UI](https://github.com/user-attachments/assets/2b8fa87a-a251-4725-a48e-d0a500174871)

## Summary

Redesigns the language selector and translation panel with a unified pill UI, sliding highlight animations, SSR-safe state, Apple-style design, and expanded test coverage.

## Changes

### Language selector redesign
- **Unified pill container** across mobile and desktop — replaces separate mobile pill + desktop tab row + standalone search icon with a single `overflow-hidden rounded-2xl` container. Mobile shows selected language name; desktop shows recent language tabs; search icon is always right-aligned inside.
- **Sliding highlight**: absolutely positioned `bg-white/50` div transitions between active tabs (`transition-[left,width] duration-300 ease-out`). Remeasures on window resize via passive listener.
- **Pill-enter animation**: when a new language is added to the tab row, it grows from 0 width/padding/opacity via CSS `@keyframes pill-enter` (0.3s ease-out). The active entering tab carries the highlight background directly so both animations appear as one unified motion. `newTabCodes` state is cleared on `animationEnd` for a clean handoff to the floating highlight.
- **Stable tab order**: clicking an existing tab just slides the highlight — recents only reorder when a genuinely new language is introduced from the dropdown or via swap.
- **Swap-on-collision**: instead of hiding the other side's language via `excludeCode`, all languages are always visible. Selecting a language matching the other side swaps both languages and text, with full cleanup (`cancelPendingRequest`, `setError(null)`, `setStats(null)`).

### Dropdown positioning
- **Anchored dropdowns**: `dropdownAnchorRef` prop positions the dropdown over the textarea panel (desktop) or below the language row (mobile) using `fixed` positioning with viewport-based height capping (`min(remaining, 560px, 70vh)`).
- **Flip above**: when space below anchor < 160px with more room above, dropdown flips up. Height clamped to non-negative values.
- **Passive scroll/resize listeners** for anchor measurement.
- Right-edge fade mask on desktop tabs for clipped language names.
- `scrollbar-gutter: stable` on dropdown list.

### State management
- **SSR-safe restore**: `useLayoutEffect` + `hasRestored` conditional mount — language pills only render after localStorage restore completes in a single state commit, preventing hydration mismatches and flash of default content.
- **Lifted recents state**: `TranslationPanel` owns `sourceRecents`/`targetRecents`; `LanguageSelector` is presentational via `recents`/`onRecentsChange` props. `loadRecents`, `saveRecents`, `addToRecents` exported as utilities.
- **No-reorder restore**: persisted recents keep their stored order on load; only `addToRecents` if the selected language is missing from the list.

### Apple-style design
- `rounded-2xl` uniformly across panels, pills, dropdowns, inputs.
- Panels: `shadow-sm ring-1 ring-zinc-900/5` (no flat borders).
- `text-[13px]` pills, consistent `gap-3` spacing, `p-5` panel padding, `px-4` toolbars.
- Lighter pill fills (`bg-zinc-100`/`dark:bg-zinc-800`), semi-transparent toolbar dividers (`border-zinc-100/60`).
- Thin 6px scrollbar with transparent track.

### Tests (69 total, up from 56)
- localStorage restore, invalid codes, localStorage throws fallback.
- Swap languages via button, swap-on-collision via language selection.
- Stable recents (no `onRecentsChange` when selecting existing tab).
- Escape closes dropdown.