### PR TITLE
ci: add dependabot with auto-merge on passing CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto-merge Dependabot PRs
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration for weekly npm and GitHub Actions dependency updates, grouped into single PRs.
- Adds auto-merge workflow that enables squash auto-merge on Dependabot PRs — GitHub merges automatically once all required CI checks (typecheck, lint, format, test) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Dependabot configuration for automated dependency updates on a weekly schedule for npm packages and GitHub Actions.
  * Added GitHub Actions workflow to automatically squash-merge Dependabot pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->