### PR TITLE
chore: split eslint into separate dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,18 @@ updates:
     schedule:
       interval: weekly
     groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
       all-dependencies:
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
         patterns:
           - "*"
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

- Split eslint packages into their own dependabot group so peer dep conflicts with eslint 10 don't block other dependency updates
- The eslint group PR will fail weekly until plugins publish v10 support, then auto-merge — no manual tracking needed

## Test plan

- [ ] Non-eslint deps get their own PR and auto-merge
- [ ] eslint group PR fails independently without blocking others