### PR TITLE
chore: group only minor/patch deps, isolate major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,10 @@ updates:
     schedule:
       interval: weekly
     groups:
-      eslint:
-        patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@eslint/*"
-          - "typescript-eslint"
       all-dependencies:
-        exclude-patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@eslint/*"
-          - "typescript-eslint"
+        update-types:
+          - "minor"
+          - "patch"
         patterns:
           - "*"
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

- Group all minor/patch updates into a single auto-mergeable PR
- Major version bumps get individual PRs — they fail independently until ecosystem compatibility lands, without blocking patches/minors
- Simpler config: no need to maintain separate package lists per group