### PR TITLE
refactor: remove English special-case from locale detection

### DIFF
--- a/src/lib/localeDetect.test.ts
+++ b/src/lib/localeDetect.test.ts
@@ -10,14 +10,14 @@ describe("detectTargetLocale", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns null for English locale", () => {
+  it("returns en for English locale", () => {
     mockNavigatorLanguage("en");
-    expect(detectTargetLocale()).toBeNull();
+    expect(detectTargetLocale()).toBe("en");
   });
 
-  it("returns null for English with region", () => {
+  it("returns en for English with region", () => {
     mockNavigatorLanguage("en-US");
-    expect(detectTargetLocale()).toBeNull();
+    expect(detectTargetLocale()).toBe("en");
   });
 
   it("returns exact match for fr-FR", () => {

--- a/src/lib/localeDetect.ts
+++ b/src/lib/localeDetect.ts
@@ -2,12 +2,13 @@ import { VALID_LANGUAGE_CODES } from "./languages";
 
 /**
  * Detect the browser locale and map it to a supported language code.
- * Returns null if locale is English or not supported.
+ * Returns null if locale is not supported.
  *
  * Matching strategy (in order):
  * 1. Exact match: "fr-FR" -> "fr_FR"
  * 2. Language + region: "zh-Hant-TW" -> "zh_TW" (skip script subtag)
  * 3. Language prefix match: "fr" -> first code starting with "fr_"
+ * 4. Bare language fallback: "en-US" -> "en"
  */
 export function detectTargetLocale(): string | null {
   if (typeof navigator === "undefined") return null;
@@ -16,8 +17,6 @@ export function detectTargetLocale(): string | null {
   if (!browserLocale) return null;
 
   const underscored = browserLocale.replaceAll("-", "_");
-
-  if (underscored === "en" || underscored.startsWith("en_")) return null;
 
   if (VALID_LANGUAGE_CODES.has(underscored)) return underscored;
 
@@ -36,6 +35,9 @@ export function detectTargetLocale(): string | null {
   for (const code of VALID_LANGUAGE_CODES) {
     if (code.startsWith(lang + "_")) return code;
   }
+
+  // Bare language code (e.g. "en" from "en-US")
+  if (VALID_LANGUAGE_CODES.has(lang)) return lang;
 
   return null;
 }


### PR DESCRIPTION
## Summary

- Remove hardcoded `en` early-return from `detectTargetLocale()`
- English now goes through the same lookup path as every other locale
- Since `translatedLabels` has no `en` entry, `getLabelsForLocale` naturally falls back to `DEFAULT_LABELS` (which is English)

## Test plan

- [x] `npm run check` passes
- [x] `npm test` passes (80/80)
- [x] Set browser to English — UI labels remain English (same behavior, no special path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * English locales (including region variants) are now correctly detected and supported.
* **Tests**
  * Updated locale detection tests to reflect correct handling of English locale cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->