### PR TITLE
fix: pin source status bar to bottom when target panel is taller

### DIFF
--- a/src/components/TranslationPanel.tsx
+++ b/src/components/TranslationPanel.tsx
@@ -366,7 +366,7 @@ export function TranslationPanel() {
             placeholder={placeholderSource}
             className="min-h-48 w-full resize-none overflow-hidden bg-transparent p-5 text-lg focus:outline-none"
           />
-          <div className="flex h-10 items-center justify-end gap-3 px-4">
+          <div className="mt-auto flex h-10 items-center justify-end gap-3 px-4">
             <button
               type="button"
               onClick={handleClear}


### PR DESCRIPTION
## Summary

- When translated text is longer than source text, the grid row grows to match the taller target panel. The source panel's status bar (clear button + char count) was floating mid-panel instead of staying at the bottom
- Fix: add `mt-auto` to the source status bar div, pushing it to the bottom of the flex column

## Test plan

- [x] `npm run check` passes
- [x] `npm test` passes (80/80)
- [x] Paste multi-line text, wait for translation — source status bar stays pinned to the bottom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the positioning of the clear button and character count in the Source text panel; these elements now align at the bottom of the container for improved layout organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->