### PR TITLE
ci: add explicit permissions to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an explicit `permissions: contents: read` block to `.github/workflows/build.yml`, the minimum needed for `actions/checkout`.
- Docker Hub auth uses repo secrets (`DOCKER_USERNAME` / `DOCKER_PASSWORD`) and the `type=gha` cache uses `ACTIONS_RUNTIME_TOKEN`, so neither is affected by the new `permissions` scope.
- Resolves CodeQL alert [#1](https://github.com/realies/translategemma-ui/security/code-scanning/1) (`actions/missing-workflow-permissions`).

## Test plan
- [ ] Verify the next push to `main` builds and pushes the image successfully
- [ ] Confirm CodeQL alert #1 closes automatically once the change lands on `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enforce explicit permission settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/realies/translategemma-ui/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->