### PR TITLE
fix: self-host Inter font

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,4 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      - run: npm run test:production-font

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 .output/
 .vinxi/
 dist/
+playwright-report/
+test-results/
 
 # Environment files
 .env
@@ -30,4 +32,3 @@ src/routeTree.gen.ts
 
 # Local dev instructions
 CLAUDE.md
-

--- a/e2e/font-assets.spec.ts
+++ b/e2e/font-assets.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+const GOOGLE_FONT_HOSTS = ["fonts.googleapis.com", "fonts.gstatic.com"];
+
+test("serves Inter from local production assets", async ({ baseURL, request }) => {
+  if (!baseURL) throw new Error("Playwright baseURL is not configured");
+
+  const pageResponse = await request.get("/");
+  expect(pageResponse.ok()).toBe(true);
+
+  const html = await pageResponse.text();
+  for (const host of GOOGLE_FONT_HOSTS) {
+    expect(html).not.toContain(host);
+  }
+
+  const stylesheetHref = /href="([^"]+\.css)"/.exec(html)?.[1];
+  expect(stylesheetHref, "the production page should link its compiled stylesheet").toBeTruthy();
+  if (!stylesheetHref) throw new Error("Compiled stylesheet link was not found");
+
+  const stylesheetUrl = new URL(stylesheetHref, baseURL);
+  expect(stylesheetUrl.origin).toBe(new URL(baseURL).origin);
+
+  const stylesheetResponse = await request.get(stylesheetUrl.toString());
+  expect(stylesheetResponse.ok()).toBe(true);
+
+  const css = await stylesheetResponse.text();
+  expect(css).toMatch(/font-family:\s*["']?Inter Variable["']?/);
+  expect(css).toMatch(/--font-sans:\s*["']?Inter Variable["']?/);
+  for (const host of GOOGLE_FONT_HOSTS) {
+    expect(css).not.toContain(host);
+  }
+
+  const fontPaths = [...css.matchAll(/url\(([^)]+\.woff2)\)/g)].map((match) =>
+    (match[1] ?? "").replaceAll(/["']/g, "").trim()
+  );
+  const interFontPath = fontPaths.find((path) => path.includes("inter-"));
+  expect(
+    interFontPath,
+    "the compiled stylesheet should reference a local Inter WOFF2"
+  ).toBeTruthy();
+  if (!interFontPath) throw new Error("Compiled Inter WOFF2 reference was not found");
+
+  const fontUrl = new URL(interFontPath, stylesheetUrl);
+  expect(fontUrl.origin).toBe(new URL(baseURL).origin);
+
+  const fontResponse = await request.get(fontUrl.toString());
+  expect(fontResponse.ok()).toBe(true);
+  expect(fontResponse.headers()["content-type"]).toContain("font/woff2");
+
+  const fontBytes = await fontResponse.body();
+  expect(fontBytes.byteLength).toBeGreaterThan(4);
+  expect(fontBytes.subarray(0, 4).toString("ascii")).toBe("wOF2");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "translategemma-ui",
       "version": "1.0.0",
       "dependencies": {
+        "@fontsource-variable/inter": "5.3.0",
         "@tanstack/react-router": "1.170.32",
         "@tanstack/react-start": "1.168.49",
         "@vitejs/plugin-react": "6.1.0",
@@ -748,6 +749,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.3.0.tgz",
+      "integrity": "sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/node": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "5.3.0",
     "@tanstack/react-router": "1.170.32",
     "@tanstack/react-start": "1.168.49",
     "@vitejs/plugin-react": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate": "tsr generate",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:production-font": "npm run build && playwright test e2e/font-assets.spec.ts",
     "test:watch": "vitest",
     "check": "npm run typecheck && npm run lint:check && npm run format:check",
     "record-demo": "node scripts/record-demo.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+const port = "4173";
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  reporter: "line",
+  use: { baseURL },
+  webServer: {
+    command: "npm start",
+    url: `${baseURL}/health`,
+    env: {
+      HOST: "127.0.0.1",
+      PORT: port,
+    },
+    timeout: 30_000,
+  },
+});

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { createRootRoute, Outlet, HeadContent, Scripts } from "@tanstack/react-router";
+import "@fontsource-variable/inter/wght.css";
 import "../styles.css";
 
 export const Route = createRootRoute({
@@ -9,13 +10,7 @@ export const Route = createRootRoute({
       { name: "description", content: "Translate text between 55 languages using TranslateGemma" },
       { name: "theme-color", content: "#3b82f6" },
     ],
-    links: [
-      { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" },
-      {
-        rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap",
-      },
-    ],
+    links: [{ rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
   }),
   component: RootComponent,
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
 }
 
 body {

--- a/src/test/root-route.test.tsx
+++ b/src/test/root-route.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { Route } from "../routes/__root";
+
+describe("root document", () => {
+  it("does not load Google Fonts", async () => {
+    const head = await Route.options.head?.({} as never);
+    const googleFontOrigins = ["https://fonts.googleapis.com", "https://fonts.gstatic.com"];
+    const googleFontLinks = head?.links?.filter((link) =>
+      googleFontOrigins.some((origin) => link?.href?.startsWith(origin))
+    );
+
+    expect(googleFontLinks).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
       "~/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "*.config.*"]
+  "include": ["src/**/*", "e2e/**/*", "*.config.*"]
 }


### PR DESCRIPTION
## Summary

- bundle the Inter variable font with the application instead of loading it from Google Fonts
- retain the existing typography and system-font fallbacks
- add regression coverage preventing the Google Fonts integration from returning

## Test plan

- [x] `npm run generate`
- [x] `npm run typecheck`
- [x] `npm run lint:check`
- [x] `npm run format:check`
- [x] `npm test` (94 tests)
- [x] `npm run test:production-font`
- [x] Build and run the Docker image against the local Ollama instance
- [x] Verify Inter loads from a local WOFF2 asset with no external font request
- [x] Verify a live translation through the container

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fonts are now served locally, improving reliability and removing reliance on Google Fonts.
  - Added automated checks to verify local Inter font assets are correctly served in production.

- **Tests**
  - Added end-to-end coverage for font loading and external font references.
  - Production font checks now run as part of CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->